### PR TITLE
Fix for JSON Task struct

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -27,7 +27,7 @@ type Task_t struct {
 	Due_on          string
 	Tags            []Base
 	Workspace       Base
-	Parent          string
+	Parent          Base
 	Projects        []Base
 	Folloers        []Base
 }

--- a/commands/task.go
+++ b/commands/task.go
@@ -18,7 +18,7 @@ func Task(c *cli.Context) {
 	fmt.Printf("\n%s\n", t.Notes)
 
 	if stories != nil {
-		fmt.Println("\n----------------------------------------\n")
+		fmt.Printf("\n----------------------------------------\n")
 		for _, s := range stories {
 			fmt.Printf("%s\n", s)
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -23,7 +23,7 @@ func Home() string {
 
 func Check(err error) {
 	if err != nil {
-		log.Fatal("fatal: %v\n", err)
+		log.Fatalf("fatal: %v\n", err)
 	}
 }
 
@@ -72,7 +72,7 @@ func searchBrowserLauncher(goos string) (browser string) {
 		browser = "cmd /c start"
 	default:
 		candidates := []string{"xdg-open", "cygstart", "x-www-browser", "firefox",
-		"opera", "mozilla", "netscape"}
+			"opera", "mozilla", "netscape"}
 		for _, b := range candidates {
 			path, err := exec.LookPath(b)
 			if err == nil {


### PR DESCRIPTION
Previously, the Parent parameter was set as a string from the Asana API,
at some point in time, it was modified to become another Base object
(containing id, gid, and name). This commit updates the Tast_t struct to
represent the latest Asana API.